### PR TITLE
Fixed build issue in docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN go mod download
 
 # Copy the go source
 COPY main.go main.go
-COPY apis/ apis/
 COPY controllers/ controllers/
 COPY internal/ internal/
 


### PR DESCRIPTION
Currently, it is not possible to create a release as the docker build fails due to it trying to copy a folder that does not exist.

This change fixes the issue by removing the copy statement.