### PR TITLE
Do not include crd in default bases when no crd exist

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -13,7 +13,7 @@ namePrefix: cluster-identity-controller-
 #  someName: someValue
 
 bases:
-- ../crd
+#- ../crd
 - ../rbac
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in


### PR DESCRIPTION
Currently, generate_config fails downstream due to its base having a bug.

The PR fixes it.