### PR TITLE
Disable rbac proxy so prometheus can scrape it

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -28,7 +28,7 @@ patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
+# - manager_auth_proxy_patch.yaml
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type


### PR DESCRIPTION
Currently, the service is being deployed with a rbac proxy include.

It has the effect that prometheus cannot scrape it so we choose to remove it.