### PR TITLE
Add configmap watch rbac permission to pod reconciler as the logs suggest that it is required

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -14,6 +14,7 @@ rules:
   - create
   - delete
   - get
+  - list
   - update
   - watch
 - apiGroups:

--- a/controllers/core/pod_controller.go
+++ b/controllers/core/pod_controller.go
@@ -40,7 +40,7 @@ type PodReconciler struct {
 
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
-//+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;watch;create;update;delete
+//+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
Currently, we see logs like the following:
```
reflector.go:138] pkg/mod/k8s.io/client-go@v0.21.2/tools/cache/reflector.go:167: Failed to watch *v1.ConfigMap: failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:operators:cluster-identity-controller-controller-manager" cannot list resource "configmaps" in API group "" at the cluster scope
```

This PR adds the watch rbac permission to the pod reconciler.