### PR TITLE
Migrate to the new Kubernetes community-owned image registry

### DIFF
--- a/controllers/core/data_test.go
+++ b/controllers/core/data_test.go
@@ -80,7 +80,7 @@ func kubeControllerManagerPod(clusterName string) corev1.Pod {
 			Containers: []corev1.Container{
 				{
 					Name:  "kube-controller-manager",
-					Image: "k8s.gcr.io/kube-controller-manager:v1.20.8",
+					Image: "registry.k8s.io/kube-controller-manager:v1.20.8",
 					Command: []string{
 						"/usr/local/bin/kube-controller-manager",
 					},


### PR DESCRIPTION
k8s.gcr.io image registry will be frozen from the 3rd of April 2023.

https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/